### PR TITLE
Resolve node_modules paths with require.

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,19 @@
 module.exports = {
-    "extends": "google",
-    rules: {
-      // This is silly. Negated conditions are highly useful and often much more concise than
-      // their complements.
-      "no-negated-condition": "off"
-    }
+  "extends": "google",
+  "parserOptions": {
+    "ecmaVersion": 6
+  },
+  rules: {
+    // don't dangle commas
+    "comma-dangle": ["error", "never"],
+    // pre-ES6 engines need to be able to use objects as maps
+    "guard-for-in": "off",
+    // increase max line length
+    "max-len": ["error", { "code": 120 }],
+    // This is silly. Negated conditions are highly useful and often much more concise than
+    // their complements.
+    "no-negated-condition": "off",
+    // allow use of var
+    "no-var": "off"
+  }
 };

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ const fs = require('fs');
 const path = require('path');
 
 const pythonCmd = 'python';
-const closureBuilder = path.join('google-closure-library', 'closure', 'bin',
-    'build', 'closurebuilder.py');
+
+const closureLibPath = path.dirname(require.resolve(path.join('google-closure-library', 'package.json')));
+const closureBuilder = path.join(closureLibPath, 'closure', 'bin', 'build', 'closurebuilder.py');
 
 /**
  * Create a Closure manifest.
@@ -18,22 +19,12 @@ const closureBuilder = path.join('google-closure-library', 'closure', 'bin',
 const createManifest = function(options, basePath) {
   basePath = basePath || options.basePath;
 
-  // if installed as a dependency, google-closure-library may be up a directory
-  var searchPaths = [
-    path.resolve(__dirname, 'node_modules', closureBuilder),
-    path.resolve(__dirname, '..', closureBuilder)
-  ];
-
-  var gcbPath = searchPaths.find(function(searchPath) {
-    return fs.existsSync(searchPath);
-  });
-
-  if (!gcbPath) {
+  if (!closureBuilder) {
     console.error('ERROR: Could not locate closurebuilder.py!');
     return Promise.resolve();
   }
 
-  var args = [gcbPath];
+  var args = [closureBuilder];
   args = args.concat(options.js.filter(function(path) {
     return path.indexOf('!') !== 0;
   }).map(function(path) {
@@ -64,7 +55,7 @@ const createManifest = function(options, basePath) {
       // the Python logging module logs to stderr by default, so even info
       // messages will appear in stderr. detect these and write them to the
       // console
-      if (data.startsWith(gcbPath)) {
+      if (data.startsWith(closureBuilder)) {
         console.log(data);
       } else {
         errorData += data;

--- a/os-compile.js
+++ b/os-compile.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const ClosureCompiler = require('google-closure-compiler').compiler;
+const childProcess = require('child_process');
+const Promise = require('bluebird');
+
+let args;
+if (process.argv.length < 3) {
+  console.error('Please provide the compiler arguments');
+  process.exit(1);
+} else {
+  args = process.argv.slice(2);
+}
+
+const compile = function(args) {
+  return new Promise(function(resolve, reject) {
+    let javaArgs = ['-jar', ClosureCompiler.COMPILER_PATH].concat(args);
+
+    const process = childProcess.spawn('java', javaArgs);
+    process.stdout.on('data', function(data) {
+      console.log(data.toString());
+    });
+
+    process.stderr.on('data', function(data) {
+      console.log(data.toString());
+    });
+
+    process.on('error', function(err) {
+      throw new Error('Closure Compiler failed: ' + (err.message || 'Unspecified error'));
+    });
+
+    process.on('exit', function(code) {
+      resolve();
+    });
+  });
+};
+
+compile(args);

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "1.1.0",
   "description": "Helper functions for working with opensphere-build-resolver and the Google Closure Compiler",
   "main": "index.js",
+  "bin": {
+    "os-compile": "./os-compile.js"
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "package:update": "if git diff --name-only ORIG_HEAD HEAD | grep --quiet package.json; then npm update && npm install; fi",
@@ -32,7 +35,7 @@
   "license": "Apache-2.0",
   "config": {
     "commitizen": {
-      "path": "node_modules/cz-conventional-changelog"
+      "path": "cz-conventional-changelog"
     },
     "validate-commit-msg": {
       "helpMessage": "\nPlease fix your commit message (consider using 'npm i -g commitizen'). Well-formatted commit messages allow us to automate our changelog and npm releases.\n\nExamples:\n\"fix(copy-view): Fixed an error when resolving paths for view directories\"\n\"feat(gcc): Added support for defines\"\n\nIf you have installed commitizen, try running 'git cz'."
@@ -62,6 +65,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
+    "google-closure-compiler": "^20171203.0.0",
     "google-closure-library": "^20171203.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Using `require` to resolve `node_modules` paths allows using a yarn workspace with a shared `node_modules` directory. Also adds an `os-compile` process so projects switching to yarn don't have to use a direct path to the Closure compiler in their `package.json`.

These changes are compatible with an npm-based workspace.