### PR TITLE
Use the compiler's JS API instead of invoking a Java process.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const Compiler = require('google-closure-compiler').compiler;
 const Promise = require('bluebird');
 const childProcess = require('child_process');
 const fs = require('fs');
@@ -9,6 +10,26 @@ const pythonCmd = 'python';
 
 const closureLibPath = path.dirname(require.resolve(path.join('google-closure-library', 'package.json')));
 const closureBuilder = path.join(closureLibPath, 'closure', 'bin', 'build', 'closurebuilder.py');
+
+/**
+ * Run the Closure Compiler with the provided options.
+ * @param {Object} options The compiler options.
+ * @return {Promise} A promise that resolves when compilation is finished.
+ */
+const compile = function(options) {
+  const compiler = new Compiler(options);
+  return new Promise(function(resolve, reject) {
+    compiler.run((exitCode, stdOut, stdErr) => {
+      if (exitCode) {
+        process.stderr.write(stdErr, () => reject(exitCode));
+      } else {
+        process.stderr.write(stdErr);
+        process.stdout.write(stdOut);
+        resolve();
+      }
+    });
+  });
+};
 
 /**
  * Create a Closure manifest.
@@ -135,6 +156,7 @@ const readManifest = function(manifestPath, optBasePath) {
 };
 
 module.exports = {
+  compile: compile,
   createManifest: createManifest,
   fileToLines: fileToLines,
   readManifest: readManifest

--- a/os-compile.js
+++ b/os-compile.js
@@ -2,43 +2,12 @@
 
 'use strict';
 
-const ClosureCompiler = require('google-closure-compiler').compiler;
-const childProcess = require('child_process');
-const Promise = require('bluebird');
+const path = require('path');
+const compile = require('./index.js').compile;
 
-let args;
 if (process.argv.length < 3) {
-  console.error('Please provide the compiler arguments');
+  console.error('Please provide the path to the compiler options');
   process.exit(1);
-} else {
-  args = process.argv.slice(2);
 }
 
-const compile = function(args) {
-  return new Promise(function(resolve, reject) {
-    let javaArgs = ['-jar', ClosureCompiler.COMPILER_PATH].concat(args);
-
-    const javaProcess = childProcess.spawn('java', javaArgs);
-    javaProcess.stdout.on('data', function(data) {
-      console.log(data.toString());
-    });
-
-    javaProcess.stderr.on('data', function(data) {
-      console.log(data.toString());
-    });
-
-    javaProcess.on('error', function(err) {
-      throw new Error('Closure Compiler failed: ' + (err.message || 'Unspecified error'));
-    });
-
-    javaProcess.on('exit', function(code) {
-      if (code) {
-        process.exit(code);
-      }
-
-      resolve();
-    });
-  });
-};
-
-compile(args);
+compile(require(path.resolve(process.cwd(), process.argv[2])));


### PR DESCRIPTION
BREAKING CHANGE: The `os-compile` executable now requires a path to the Closure Compiler options as a JSON file, instead of a list of arguments for the Java compiler.

Testing requires [this resolver update](https://github.com/ngageoint/opensphere-build-resolver/pull/37) to add `js_output_file` to the JSON compiler options.

Then change the `compile:gcc` script to:
`os-compile .build/gcc-args.json`

This PR also exports a generic `compile` function for invoking the compiler.