### PR TITLE
fix(compile): Exit the process when the compiler fails.

### DIFF
--- a/os-compile.js
+++ b/os-compile.js
@@ -10,4 +10,5 @@ if (process.argv.length < 3) {
   process.exit(1);
 }
 
-compile(require(path.resolve(process.cwd(), process.argv[2])));
+compile(require(path.resolve(process.cwd(), process.argv[2])))
+    .then(undefined, () => process.exit(1));


### PR DESCRIPTION
The `os-compile` process was not exiting on failure, which allowed builds to continue and pass.