### PR TITLE
Use Closure's debug loader 

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -14,7 +14,7 @@ module.exports = {
     // their complements.
     "no-negated-condition": "off",
     // allow use of var
-    "no-var": "off",
+    "no-var": "error",
     // allow rejecting a promise without an error
     "prefer-promise-reject-errors": "off"
   }

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -13,8 +13,6 @@ module.exports = {
     // This is silly. Negated conditions are highly useful and often much more concise than
     // their complements.
     "no-negated-condition": "off",
-    // allow use of var
-    "no-var": "error",
     // allow rejecting a promise without an error
     "prefer-promise-reject-errors": "off"
   }

--- a/index.js
+++ b/index.js
@@ -10,8 +10,9 @@ const pythonCmd = 'python';
 
 const closureLibPath = path.dirname(require.resolve(path.join('google-closure-library', 'package.json')));
 const closureSrcPath = path.join(closureLibPath, 'closure', 'goog');
-const closureBuilder = path.join(closureLibPath, 'closure', 'bin', 'build', 'closurebuilder.py');
-const depsWriter = path.join(closureLibPath, 'closure', 'bin', 'build', 'depsWriter.py');
+const closureBinPath = path.join(closureLibPath, 'closure', 'bin', 'build');
+const closureBuilder = path.join(closureBinPath, 'closurebuilder.py');
+const depsWriter = path.join(closureBinPath, 'depsWriter.py');
 
 /**
  * Run the Closure Compiler with the provided options.
@@ -47,93 +48,27 @@ const createManifest = function(options, basePath) {
     return Promise.resolve();
   }
 
-  var args = [closureBuilder];
-  args = args.concat(options.js.filter(function(path) {
-    return path.indexOf('!') !== 0;
-  }).map(function(path) {
-    return '--root=' + path.replace(/\*\*\.js$/, '');
-  }));
+  const roots = options.js.filter(notExclude).map(mapRoot);
+  const namespaces = options.entry_point.map(mapNamespace);
+  const args = [closureBuilder, ...roots, ...namespaces];
 
-  args = args.concat(options.entry_point.map(function(entry) {
-    return '--namespace=' + entry.replace(/^goog:/, '');
-  }));
+  console.log('Creating file manifest with Closure builder...');
 
-  return new Promise(function(resolve, reject) {
-    console.log('Creating file manifest with Closure builder...');
-    console.log(pythonCmd, args);
-
-    var process = childProcess.spawn(pythonCmd, args);
-    var errorData = '';
-    var outputData = '';
-
-    // listen for source files
-    process.stdout.on('data', function(data) {
-      outputData += data.toString();
+  return execPythonCmd(args).then(function(output) {
+    let files = output.split('\n').filter(function(file) {
+      return Boolean(file);
     });
 
-    // listen for source files
-    process.stderr.on('data', function(data) {
-      data = data.toString().trim();
+    if (basePath) {
+      files = files.map(function(file) {
+        // resolve links in the file path
+        file = fs.realpathSync(file);
 
-      // the Python logging module logs to stderr by default, so even info
-      // messages will appear in stderr. detect these and write them to the
-      // console
-      if (data.startsWith(closureBuilder)) {
-        console.log(data);
-      } else {
-        errorData += data;
-      }
-    });
-
-    process.on('error', function(err) {
-      console.error('ERROR: Failed creating manifest:');
-
-      if (err.code === 'ENOENT') {
-        console.error('Python not found in path.');
-      } else {
-        console.error(err.message || 'Closure builder process failed.');
-      }
-
-      reject();
-    });
-
-    // handle python script complete
-    process.on('exit', function(code) {
-      if (code) {
-        console.error('ERROR: failed to create manifest');
-        console.error(errorData);
-        reject();
-      }
-
-      var files = outputData.split('\n').filter(function(file) {
-        return Boolean(file);
+        return path.relative(basePath, file);
       });
+    }
 
-      if (basePath) {
-        files = files.map(function(file) {
-          // resolve links in the file path
-          file = fs.realpathSync(file);
-
-          return path.relative(basePath, file);
-        });
-      }
-
-      resolve(files);
-    });
-  });
-};
-
-/**
- * Turns a file into an array of lines
- *
- * @param {string} path The path to the file
- * @return {Array<string>} The file split into lines
- */
-const fileToLines = function(path) {
-  var manifest = fs.readFileSync(path, 'utf8');
-
-  return manifest.split(/[\r\n]+/).filter(function(item) {
-    return Boolean(item);
+    return files;
   });
 };
 
@@ -146,7 +81,7 @@ const fileToLines = function(path) {
  * @return {Array<string>} The array of file paths listed in the manifest
  */
 const readManifest = function(manifestPath, optBasePath) {
-  var files = fileToLines(manifestPath);
+  let files = fileToLines(manifestPath);
 
   if (optBasePath) {
     files = files.map(function(file) {
@@ -169,24 +104,115 @@ const writeDebugLoader = function(options, outputFile) {
     return Promise.resolve();
   }
 
-  var args = [depsWriter];
-  args = args.concat(options.js.filter(function(jsPath) {
-    // the closure library provides its own deps file
-    return jsPath.indexOf('!') !== 0 && jsPath.indexOf('google-closure-library') === -1;
-  }).map(function(jsPath) {
-    jsPath = jsPath.replace(/\*\*\.js$/, '');
+  const roots = options.js.filter(notExclude).filter(notGoog).map(mapRootWithPrefix);
+  const args = [depsWriter, ...roots];
 
-    const relPath = path.relative(closureSrcPath, jsPath);
-    return `--root_with_prefix=${jsPath} ${relPath}`;
-  }));
+  console.log('Creating debug application loader...');
 
+  return execPythonCmd(args).then(function(output) {
+    // bootstrap each entry_point namespace to load the application
+    const bootstrapNamespaces = options.entry_point.map(mapBootstrapNamespace).join(',');
+    const bootstrapJs = `goog.bootstrap([${bootstrapNamespaces}]);`;
+
+    const fileContent = [
+      output,
+      // force goog.modules to wait for legacy goog.provide files to load
+      'goog.Dependency.defer_ = true;',
+      bootstrapJs
+    ];
+
+    console.log('Writing ' + outputFile);
+
+    return fs.writeFileAsync(outputFile, fileContent.join('\n'));
+  }, function(error) {
+    console.error('ERROR: Failed creating debug application loader:');
+    console.error(error);
+  });
+};
+
+/**
+ * Turns a file into an array of lines
+ *
+ * @param {string} path The path to the file
+ * @return {Array<string>} The file split into lines
+ */
+const fileToLines = function(path) {
+  const manifest = fs.readFileSync(path, 'utf8');
+
+  return manifest.split(/[\r\n]+/).filter(function(item) {
+    return Boolean(item);
+  });
+};
+
+/**
+ * Filter out exclusion glob patterns.
+ * @param {string} pattern The pattern
+ * @return {boolean} If the pattern is an exclusion
+ */
+const notExclude = function(pattern) {
+  return !pattern.startsWith('!');
+};
+
+/**
+ * Filter out exclusion glob patterns.
+ * @param {string} pattern The pattern
+ * @return {boolean} If the pattern is an exclusion
+ */
+const notGoog = function(pattern) {
+  return pattern.indexOf('google-closure-library') === -1;
+};
+
+/**
+ * Convert an entry point to a namespace string for `goog.bootstrap`.
+ * @param {string} entry The entry point
+ * @return {boolean} The argument
+ */
+const mapBootstrapNamespace = function(entry) {
+  return `'${entry.replace(/^goog:/, '')}'`;
+};
+
+/**
+ * Convert an entry point to a `--namespace` argument for `closurebuilder.py`.
+ * @param {string} entry The entry point
+ * @return {boolean} The argument
+ */
+const mapNamespace = function(entry) {
+  return '--namespace=' + entry.replace(/^goog:/, '');
+};
+
+/**
+ * Convert a glob pattern to a `--root` argument for `closurebuilder.py`.
+ * @param {string} pattern The pattern
+ * @return {boolean} The argument
+ */
+const mapRoot = function(pattern) {
+  return '--root=' + pattern.replace(/\*\*\.js$/, '');
+};
+
+/**
+ * Convert a glob pattern to a `--root_with_prefix` argument for `depswriter.py`.
+ * @param {string} pattern The pattern
+ * @return {boolean} The argument
+ */
+const mapRootWithPrefix = function(pattern) {
+  pattern = pattern.replace(/\*\*\.js$/, '');
+
+  const relPath = path.relative(closureSrcPath, pattern);
+  return `--root_with_prefix=${pattern} ${relPath}`;
+};
+
+/**
+ * Execute a Python command.
+ * @param {Array} args The arguments.
+ * @return {Promise} A promise that resolves to the command output, or is rejected if there is an error.
+ */
+const execPythonCmd = function(args) {
   return new Promise(function(resolve, reject) {
-    console.log('Creating debug application loader...');
     console.log(pythonCmd, args);
 
-    var process = childProcess.spawn(pythonCmd, args);
-    var errorData = '';
-    var outputData = '';
+    const process = childProcess.spawn(pythonCmd, args);
+    let errorData = '';
+    let outputData = '';
 
     // listen for source files
     process.stdout.on('data', function(data) {
@@ -208,40 +234,16 @@ const writeDebugLoader = function(options, outputFile) {
     });
 
     process.on('error', function(err) {
-      console.error('ERROR: Failed creating debug application loader:');
-
-      if (err.code === 'ENOENT') {
-        console.error('Python not found in path.');
-      } else {
-        console.error(err.message || 'Deps writer process failed.');
-      }
-
-      reject();
+      reject(err.code === 'ENOENT' ? 'Python not found in path.' : (err.message || 'Command failed.'));
     });
 
     // handle python script complete
     process.on('exit', function(code) {
       if (code) {
-        console.error('ERROR: failed to create debug application loader');
-        console.error(errorData);
-        reject();
+        reject(errorData);
+      } else {
+        resolve(outputData);
       }
-
-      // bootstrap each entry_point namespace to load the application
-      var bootstrapNamespaces = options.entry_point.map(function(entry) {
-        return `'${entry.replace(/^goog:/, '')}'`;
-      }).join(',');
-      var bootstrapJs = `goog.bootstrap([${bootstrapNamespaces}]);`;
-
-      var fileContent = [
-        outputData,
-        // force goog.modules to wait for legacy goog.provide files to load
-        'goog.Dependency.defer_ = true;',
-        bootstrapJs
-      ];
-
-      console.log('Writing ' + outputFile);
-      fs.writeFileAsync(outputFile, fileContent.join('\n')).then(resolve, reject);
     });
   });
 };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ const closureLibPath = path.dirname(require.resolve(path.join('google-closure-li
 const closureSrcPath = path.join(closureLibPath, 'closure', 'goog');
 const closureBinPath = path.join(closureLibPath, 'closure', 'bin', 'build');
 const closureBuilder = path.join(closureBinPath, 'closurebuilder.py');
-const depsWriter = path.join(closureBinPath, 'depsWriter.py');
+const depsWriter = path.join(closureBinPath, 'depswriter.py');
 
 /**
  * Run the Closure Compiler with the provided options.
@@ -44,8 +44,7 @@ const createManifest = function(options, basePath) {
   basePath = basePath || options.basePath;
 
   if (!closureBuilder || !fs.existsSync(closureBuilder)) {
-    console.error('ERROR: Could not locate closurebuilder.py!');
-    return Promise.resolve();
+    return Promise.reject('Could not locate closurebuilder.py!');
   }
 
   const roots = options.js.filter(notExclude).map(mapRoot);
@@ -100,8 +99,7 @@ const readManifest = function(manifestPath, optBasePath) {
  */
 const writeDebugLoader = function(options, outputFile) {
   if (!depsWriter || !fs.existsSync(depsWriter)) {
-    console.error('ERROR: Could not locate depswriter.py!');
-    return Promise.resolve();
+    return Promise.reject('Could not locate depswriter.py!');
   }
 
   const roots = options.js.filter(notExclude).filter(notGoog).map(mapRootWithPrefix);


### PR DESCRIPTION
Closure provides its own debug loader in `base.js` that handles loading both legacy `goog.provide` scripts and `goog.module` scripts, based on a generated dependency list. This PR adds a new `writeDebugLoader` call to generate a script containing:

- `goog.addDependency` calls for all source files, generated with [Closure's DepsWriter](https://developers.google.com/closure/library/docs/depswriter).
- A call to ensure `goog.module` files wait on legacy `goog.provide` dependencies to load before loading themselves.
- A `goog.bootstrap` call to load the application entry point(s).

Other changes:
- Abstract code to run a Python command and return its output into `execPythonCmd`.
- Create utility functions to clean up filter/map/etc calls.