### PR TITLE
fix(debug): allow the caller to handle debug loader rejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,9 +122,6 @@ const writeDebugLoader = function(options, outputFile) {
     console.log('Writing ' + outputFile);
 
     return fs.writeFileAsync(outputFile, fileContent.join('\n'));
-  }, function(error) {
-    console.error('ERROR: Failed creating debug application loader:');
-    console.error(error);
   });
 };
 


### PR DESCRIPTION
The caller's rejection handler should receive the error and determine what to do with it. In `opensphere-build-index`, this will fail the build by throwing an error. Currently the build continues because the rejection is handled.