### PR TITLE
feat(goog): update closure compiler to latest

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,6 +23,9 @@ const depsWriter = path.join(closureBinPath, 'depswriter.py');
  * @return {Promise} A promise that resolves when compilation is finished.
  */
 const compile = function(options) {
+  const gccPackage = require('google-closure-compiler/package.json');
+  console.log(`Closure Compiler version: ${gccPackage.version}`);
+
   const compiler = new Compiler(options);
   return new Promise(function(resolve, reject) {
     compiler.run((exitCode, stdOut, stdErr) => {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "google-closure-compiler": "20190415.0.0",
+    "google-closure-compiler": "20200112.0.0",
     "google-closure-library": "20200112.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
BREAKING CHANGE: The Closure Compiler update changes available error groups. This requires `opensphere-build-resolver@7.0.0`. The compiler update may also report new errors in compiled code.

Related PR: https://github.com/ngageoint/opensphere-build-resolver/pull/57