### PR TITLE
chore: use native binaries rather than java jar

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,10 +30,12 @@ const compile = function(options) {
   const compiler = new Compiler(options);
 
   // use native versions so we don't have a dep on Java
-  compiler.JAR_PATH = null;
-  compiler.javaPath = getNativeImagePath();
+  const nativePath = getNativeImagePath();
 
-  if (!compiler.javaPath) {
+  if (nativePath) {
+    compiler.JAR_PATH = null;
+    compiler.javaPath = nativePath;
+  } else {
     const platformMap = {
       'linux': 'linux',
       'darwin': 'osx',
@@ -41,7 +43,7 @@ const compile = function(options) {
     };
 
     const platform = platformMap[process.platform];
-    throw new Error(`Could not find google-closure-compiler-${platform}/compiler`);
+    console.warn(`Could not find google-closure-compiler-${platform}/compiler! Falling back to Java version.`);
   }
 
   return new Promise(function(resolve, reject) {


### PR DESCRIPTION
The Closure Compiler folks release native builds to `google-closure-compiler-<platform>` on npm. `google-closure-compiler` already references those as `optionalDependencies`, so the one for your system is already sitting in `node_modules` along with `google-closure-compiler-java`. This copies in the same mechanism that `google-closure-compiler/cli.js` uses to invoke the native target instead of the Java jar.

Note that this isn't any faster (same code underneath, just with a Java-to-native build), it just removes Java as an environmental dependency.