### PR TITLE
feat(deps): add script to write closure deps

### DIFF
--- a/index.js
+++ b/index.js
@@ -336,10 +336,34 @@ const execPythonCmd = function(args) {
   });
 };
 
+/**
+ * Writes a Google Closure deps file.
+ * @param {Object} options The Closure compiler options.
+ * @param {string} outputFile The output file.
+ * @return {Promise} A promise that resolves when the file is written.
+ */
+const writeDeps = function(options, outputFile) {
+  if (!depsWriter || !fs.existsSync(depsWriter)) {
+    return Promise.reject('Could not locate depswriter.py!');
+  }
+
+  const roots = options.js.filter(notExclude).filter(notGoog).map(mapRootWithPrefix);
+  const args = [depsWriter, ...roots];
+
+  console.log('Writing Closure deps...');
+
+  return execPythonCmd(args).then(function(output) {
+    console.log(`Writing ${outputFile}`);
+
+    return fs.writeFileAsync(outputFile, output);
+  });
+};
+
 module.exports = {
-  compile: compile,
-  writeDebugLoader: writeDebugLoader,
-  createManifest: createManifest,
-  fileToLines: fileToLines,
-  readManifest: readManifest
+  compile,
+  writeDebugLoader,
+  writeDeps,
+  createManifest,
+  fileToLines,
+  readManifest
 };

--- a/os-gendeps.js
+++ b/os-gendeps.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+'use strict';
+
+const path = require('path');
+const {writeDeps} = require('./index.js');
+
+if (process.argv.length < 4) {
+  console.error('Usage: os-gendeps <gcc opts> <output>');
+  process.exit(1);
+}
+
+const depsDirs = require(path.resolve(process.cwd(), process.argv[2]));
+const outputFile = path.resolve(process.cwd(), process.argv[3]);
+writeDeps(depsDirs, outputFile);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Helper functions for working with opensphere-build-resolver and the Google Closure Compiler",
   "main": "index.js",
   "bin": {
-    "os-compile": "./os-compile.js"
+    "os-compile": "./os-compile.js",
+    "os-gendeps": "./os-gendeps.js"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",


### PR DESCRIPTION
Adds an `os-gendeps` script that invokes [DepsWriter](https://developers.google.com/closure/library/docs/depswriter) to write a deps file. The script takes a GCC JSON options file and the output file path as inputs. The Closure Library is excluded from the input sources because the library provides a deps file with each release.

Example usage:
```
os-gendeps .build/gcc-args.json .build/deps.js
```