### PR TITLE
feat(gcc): update closure compiler to 20200830.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "google-closure-compiler": "20200112.0.0",
+    "google-closure-compiler": "20200830.0.0",
     "google-closure-library": "20200112.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
BREAKING CHANGE: The latest Closure Compiler has removed the `useOfGoogBase` error group, and changed the API for some Angular externs.