### PR TITLE
feat(gcc): update closure compiler to 20210406

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,8 +57,8 @@
   },
   "dependencies": {
     "bluebird": "^3.7.2",
-    "google-closure-compiler": "20200830.0.0",
-    "google-closure-library": "20210106.0.0"
+    "google-closure-compiler": "20210406.0.0",
+    "google-closure-library": "20210302.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "bluebird": "^3.7.2",
     "google-closure-compiler": "20210406.0.0",
-    "google-closure-library": "20210302.0.0"
+    "google-closure-library": "20210406.0.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2170,10 +2170,10 @@ google-closure-compiler@20210406.0.0:
     google-closure-compiler-osx "^20210406.0.0"
     google-closure-compiler-windows "^20210406.0.0"
 
-google-closure-library@20210302.0.0:
-  version "20210302.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-library/-/google-closure-library-20210302.0.0.tgz#b8116f3fa086fbf20d54511c6117fa5dc8899503"
-  integrity sha512-xu5TytXJmPe0WxZ6Igy3Bo+XFiwrftch6iVN2E6TzKMGbZ+rnvotzWaIpigtDx6GWZVAFLok8ErT5avQkSep/w==
+google-closure-library@20210406.0.0:
+  version "20210406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-library/-/google-closure-library-20210406.0.0.tgz#47d6036c1704661ad47cde2e35f19cc55e33e775"
+  integrity sha512-1lAC/KC9R2QM6nygniM0pRcGrv5bkCUrIZb2hXFxLtAkA+zRiVeWtRYpFWDHXXJzkavKjsn9upiffL4x/nmmVg==
 
 got@^6.7.1:
   version "6.7.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2135,45 +2135,45 @@ globby@^11.0.0, globby@^11.0.1:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-google-closure-compiler-java@^20200830.0.0:
-  version "20200830.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20200830.0.0.tgz#627cbddb17fd0012f901450ee06a617bdb7023a7"
-  integrity sha512-DLlcY875mQB7PA9wtfbPBVL9chJj+si/cmxyp3euw7x09MiFYynR4tmQJ9KjWUffPbhvCRDEO/jKcVyNWQVS1Q==
+google-closure-compiler-java@^20210406.0.0:
+  version "20210406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-java/-/google-closure-compiler-java-20210406.0.0.tgz#f2be1f825e1c08027698e24dc3ad7c762a7b838d"
+  integrity sha512-hVOoFiIenZuicZSLqi4sNdwzWeg9hRi3acpvOy6WPwKQUuUNkSXNtUiiXpKgCY5puDs49onhV7FzAHoQ/908lg==
 
-google-closure-compiler-linux@^20200830.0.0:
-  version "20200830.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20200830.0.0.tgz#c231a735b29b2d94ecfbe01ce86f3182ee85495a"
-  integrity sha512-QfxFA3+fOrNe0RH2lcXmkdiaM97KvZQOtO3trobNvfkMNr2h9OUtpXkqWExwolo/jsJWNumsdaRnEAwEthMUOw==
+google-closure-compiler-linux@^20210406.0.0:
+  version "20210406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-linux/-/google-closure-compiler-linux-20210406.0.0.tgz#e31ecb9ae6cdfb4e1b02052d8f24ac457e8fd435"
+  integrity sha512-KzE39AD3OOZMkR1TtE3nwPBhB3eEJwH8w4Jm3vx2k4veFhryWASFAnDMfHcASzlzjk05tPjecuFtGrHhVafL+w==
 
-google-closure-compiler-osx@^20200830.0.0:
-  version "20200830.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20200830.0.0.tgz#daa7cf607374fc6a85e3f5be2cc323867988d607"
-  integrity sha512-qHKjRBJVq2+2mT25eoT6iOMVbUGT02sJUwkdLlsohWKV4sMEY8/nwnkZYsdm7KnPJnmQLlrfYJ1ZTh1VTlAJpQ==
+google-closure-compiler-osx@^20210406.0.0:
+  version "20210406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-osx/-/google-closure-compiler-osx-20210406.0.0.tgz#17049155b2eba6a74b383d6b013d929a8a3a6d6a"
+  integrity sha512-Kph0hewevDC2T3uEQSRFoZAI5oE18ceyx5gUy93B0fd8cbL7vUCVjazBcHKOUiQ/Opq2CT96V0moCSFEhq8d1w==
 
-google-closure-compiler-windows@^20200830.0.0:
-  version "20200830.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler-windows/-/google-closure-compiler-windows-20200830.0.0.tgz#881cb0cd5adb4002987103d6f9c91450791a0df4"
-  integrity sha512-IpJAyxJo+GQ2DSVC4sslPydhIPyWRINkdNynIK/Bk+vbM/7i4LoEm/Y5rY/KJOLRCSds+s3Ov9LYdFkN8C//7g==
+google-closure-compiler-windows@^20210406.0.0:
+  version "20210406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler-windows/-/google-closure-compiler-windows-20210406.0.0.tgz#030a8f4bc7d9aa3fbcfe6028a8b8e23bc0cab755"
+  integrity sha512-IlFWn3vv8SLCRcxK6MSfRgnU4we7zy+s6OczmEmH4wymkpRM6aydAaD4Vxz68i00Om0hkT5l2oO3cFq5FiQBLg==
 
-google-closure-compiler@20200830.0.0:
-  version "20200830.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20200830.0.0.tgz#2c76bc20b23275e4811d4b92ef0d840314910839"
-  integrity sha512-Pri8kyHGmd2xqLM38QBarx+fdkm2HuLniGz7GimbdjQ1KUuPNIz7IJOYc8NGGwYPGAB45vg4IZRk/LepAqnoxg==
+google-closure-compiler@20210406.0.0:
+  version "20210406.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-compiler/-/google-closure-compiler-20210406.0.0.tgz#954be1b1347ccfab00dbcaed5c6296133e710e0c"
+  integrity sha512-qaQqEjIneTK5OXYfZmGnWwy5S1nYLeTTphpbc7LzhsvEq4s2xapKCi6fC8VsbCHZvgq8z5VNomMJU97ErRCyGQ==
   dependencies:
     chalk "2.x"
-    google-closure-compiler-java "^20200830.0.0"
+    google-closure-compiler-java "^20210406.0.0"
     minimist "1.x"
     vinyl "2.x"
     vinyl-sourcemaps-apply "^0.2.0"
   optionalDependencies:
-    google-closure-compiler-linux "^20200830.0.0"
-    google-closure-compiler-osx "^20200830.0.0"
-    google-closure-compiler-windows "^20200830.0.0"
+    google-closure-compiler-linux "^20210406.0.0"
+    google-closure-compiler-osx "^20210406.0.0"
+    google-closure-compiler-windows "^20210406.0.0"
 
-google-closure-library@20210106.0.0:
-  version "20210106.0.0"
-  resolved "https://registry.yarnpkg.com/google-closure-library/-/google-closure-library-20210106.0.0.tgz#b85cc75ff7f092827998a779bdad1956af6cd87e"
-  integrity sha512-ONJTdzXvBZ8oQ3MscZxSmw2w1SWpIq1FI0dZQdJQQXrXRFXCsBmntj/IFGE+QTOynmOo6Ee1YTq6p2h8O3oQWA==
+google-closure-library@20210302.0.0:
+  version "20210302.0.0"
+  resolved "https://registry.yarnpkg.com/google-closure-library/-/google-closure-library-20210302.0.0.tgz#b8116f3fa086fbf20d54511c6117fa5dc8899503"
+  integrity sha512-xu5TytXJmPe0WxZ6Igy3Bo+XFiwrftch6iVN2E6TzKMGbZ+rnvotzWaIpigtDx6GWZVAFLok8ErT5avQkSep/w==
 
 got@^6.7.1:
   version "6.7.1"


### PR DESCRIPTION
BREAKING CHANGE: The updated compiler will find additional errors from previous versions, and is not compatible with old versions of the Closure library. Projects will need to update the library and resolve build errors.