### PR TITLE
fix(closure): detect multiline goog.require statements

### DIFF
--- a/closure/source.py
+++ b/closure/source.py
@@ -35,7 +35,7 @@ _MODULE_REGEX = re.compile(_BASE_REGEX_STRING % 'module')
 _ES6_REGEX = re.compile(_BASE_REGEX_STRING % 'declareModuleId')
 _PROVIDE_REGEX = re.compile(_BASE_REGEX_STRING % 'provide')
 
-_REQUIRE_REGEX_STRING = (r'^\s*(?:(?:var|let|const)\s+[a-zA-Z0-9$_,:{}\s]*'
+_REQUIRE_REGEX_STRING = (r'^\s*(?:(?:(?:var|let|const)\s+)?[a-zA-Z0-9$_,:{}\s]*'
                          r'\s*=\s*)?goog\.require\(\s*[\'"](.+)[\'"]\s*\)')
 _REQUIRES_REGEX = re.compile(_REQUIRE_REGEX_STRING)
 


### PR DESCRIPTION
`source.py` currently does not detect `goog.require` statements if they're on multiple lines. This is commonly used for destructured requires like this:

```
const {
  someExport,
  anotherExport
} = goog.require('my.module');
```

To handle this specific situation, I made the var declaration (var/let/const + whitespace) optional so it will match a line with `} = goog.require('...');`. This will generate a more accurate manifest via the `createManifest` function, and also produces more accurate dependencies in `deps.js` files.

This does not impact builds. The webpack ClosureLibrary plugin uses `deps.js` to connect module names to file paths, but does not use the dependency lists.